### PR TITLE
Optimize InvokableCases to memoize results and remove case looping

### DIFF
--- a/src/InvokableCases.php
+++ b/src/InvokableCases.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ArchTech\Enums;
 
 use BackedEnum;
+use ReflectionEnum;
 
 trait InvokableCases
 {
@@ -17,14 +18,18 @@ trait InvokableCases
     /** Return the enum's value or name when it's called ::STATICALLY(). */
     public static function __callStatic($name, $args)
     {
-        $cases = static::cases();
+        static $valueMap = [];
 
-        foreach ($cases as $case) {
-            if ($case->name === $name) {
-                return $case instanceof BackedEnum ? $case->value : $case->name;
-            }
+        if (isset($valueMap[$name])) {
+            return $valueMap[$name];
         }
 
-        throw new Exceptions\UndefinedCaseError(static::class, $name);
+        $reflEnum = new ReflectionEnum(static::class);
+        if (! $reflEnum->hasCase($name)) {
+            throw new Exceptions\UndefinedCaseError(static::class, $name);
+        }
+
+        // Get the enum case, and invoke it to get the value or name
+        return $valueMap[$name] = $reflEnum->getCase($name)->getValue()();
     }
 }


### PR DESCRIPTION
There is a high likelihood that cases will be invoked many-many times per-request.  Currently, it loops over all cases to find the one it needs on each invocation. In cases where the same enum case is invoked hundreds or thousands of times (e.g. when reading DB rows in), this causes unnecessary work. This removes the loop by using reflection, and memoizes the results.

While the performance improvement will likely be unnoticeable, and you could consider this a micro-optimization, it is about 2x as fast as the current implementation.  The real benefit is code re-use, as after it finds the enum case, it invokes it so the name/value logic is in 1 place.