### PR TITLE
Add valueOptions() to options trait

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -17,4 +17,10 @@ trait Options
             ? array_column($cases, 'value', 'name')
             : array_column($cases, 'name');
     }
+    
+    /** Get an associative array of [case value => case value]. */
+    public function valueOptions(): array
+    {
+        return array_column(static::cases(), 'value', 'value');
+    }
 }


### PR DESCRIPTION
normally it is the value that get stored in database

it is usually also the value that is more display friendly in select field as it doesn't have those _ or ALL_CAPS

Since redefining options() might be a breaking change, i propose valueOptions()

Let me know if this should be in the Values trait instead.