### PR TITLE
nunomaduro/larastan abandoned

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,9 @@
     },
     "require-dev": {
         "orchestra/testbench": "^7.0|^8.0",
-        "nunomaduro/larastan": "^1.0|^2.4",
         "pestphp/pest": "^1.2|^2.0",
-        "pestphp/pest-plugin-laravel": "^1.0|^2.0"
+        "pestphp/pest-plugin-laravel": "^1.0|^2.0",
+        "larastan/larastan": "^1.0|^2.7.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - ./vendor/nunomaduro/larastan/extension.neon
+    - ./vendor/larastan/larastan/extension.neon
     - ./extension.neon
 
 parameters:


### PR DESCRIPTION
Abandoned warning

`Package nunomaduro/larastan is abandoned, you should avoid using it. Use larastan/larastan instead.`