### PR TITLE
feat: Add support for default values on metadata properties

### DIFF
--- a/src/Meta/MetaProperty.php
+++ b/src/Meta/MetaProperty.php
@@ -12,6 +12,11 @@ abstract class MetaProperty
         $this->value = $this->transform($value);
     }
 
+    public static function defaultValue(): mixed
+    {
+        return null;
+    }
+
     public static function make(mixed $value): static
     {
         return new static($value);

--- a/src/Meta/Reflection.php
+++ b/src/Meta/Reflection.php
@@ -73,6 +73,6 @@ class Reflection
             return $properties[0]->value;
         }
 
-        return null;
+        return $metaProperty::defaultValue() ?? null;
     }
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -29,6 +29,17 @@ class Instructions extends MetaProperty
     }
 }
 
+#[Attribute]
+class IsActive extends MetaProperty
+{
+    public static string $method = 'isActive';
+
+    public static function defaultValue(): mixed
+    {
+        return false;
+    }
+}
+
 /**
  * @method string description()
  * @method string color()
@@ -60,6 +71,25 @@ enum Role
     #[Desc('Read-only guest')]
     #[Instructions('Guest users can only view the existing records')]
     case GUEST;
+}
+
+#[Meta([IsActive::class])]
+enum ReferenceType: int
+{
+    use InvokableCases, Options, Names, Values, From, Metadata, Comparable;
+
+    #[IsActive(true)]
+    case ACTIVE_TYPE = 1;
+
+    case INACTIVE_TYPE = 0;
+}
+    
+#[Meta([Desc::class])]
+enum RoleWithoutAttribute
+{
+    use InvokableCases, Options, Names, Values, From, Metadata, Comparable;
+
+    case ADMIN;
 }
 
 enum MultiWordSnakeCaseEnum

--- a/tests/Pest/MetadataTest.php
+++ b/tests/Pest/MetadataTest.php
@@ -60,4 +60,12 @@ test('fromMeta throws an exception when the enum cannot be instantiated', functi
 
 test('tryFromMeta silently fails when the enum cannot be instantiated')
     ->expect(Role::tryFromMeta(Color::make('foobar')))
-    ->toBe(null);
+    ->toBeNull();
+
+test('metadata properties return null if missing on the case')
+    ->expect(RoleWithoutAttribute::ADMIN->desc())
+    ->toBeNull();
+
+test('metadata can have default values')
+    ->expect(ReferenceType::INACTIVE_TYPE->isActive())
+    ->toBeFalse();


### PR DESCRIPTION
This PR adds support for attributes to define default values. This allows us to remove a lot of boilerplate code for attribute values that are optional.

For example, we have an enum for an instrument type and each type can optionally be marked as deprecated. Currently, we have to have a `IsDeprecated` attribute on every single enum case, when only 2 out of 15 types are currently deprecated.

This PR would allow us to only add code for the few types that are actually deprecated, by defaulting the method to return `false`.