### PR TITLE
Fix PHP 8.4 deprecation for type declaration for default null value

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -85,6 +85,7 @@ $rules = [
     'no_whitespace_in_blank_line' => true,
     'normalize_index_brace' => true,
     'not_operator_with_successor_space' => true,
+    'nullable_type_declaration_for_default_null_value' => true,
     'object_operator_without_whitespace' => true,
     'ordered_imports' => ['sort_algorithm' => 'alpha'],
     'phpdoc_indent' => true,

--- a/src/Options.php
+++ b/src/Options.php
@@ -23,7 +23,7 @@ trait Options
      * Generate a string format of the enum options using the provided callback and glue.
      * @param Closure(string $name, mixed $value): string $callback
      */
-    public static function stringOptions(Closure $callback = null, string $glue = '\n'): string
+    public static function stringOptions(?Closure $callback = null, string $glue = '\n'): string
     {
         $firstCase = static::cases()[0] ?? null;
 


### PR DESCRIPTION
- added php-cs-fixer rule `nullable_type_declaration_for_default_null_value`
- fixed deprecation