### PR TITLE
General code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ vendor/
 .php-cs-fixer.cache
 .vscode/
 .idea/
+.phpunit.cache/
 coverage/
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ composer.lock
 vendor/
 .php-cs-fixer.cache
 .vscode/
+.idea/
 coverage/
 node_modules

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -25,5 +25,4 @@ parameters:
         #    paths:
         #        - tests/*
         # - '#should return \$this#'
-
-    checkMissingIterableValueType: false
+        - identifier: missingType.iterableValue

--- a/src/Comparable.php
+++ b/src/Comparable.php
@@ -20,21 +20,9 @@ trait Comparable
         return ! $this->is($enum);
     }
 
-    public function in(array|object $enums): bool
+    public function in(iterable $enums): bool
     {
-        $iterator = $enums;
-
-        if (! is_array($enums)) {
-            if ($enums instanceof Iterator) {
-                $iterator = $enums;
-            } elseif ($enums instanceof IteratorAggregate) {
-                $iterator = $enums->getIterator();
-            } else {
-                throw new Exception('in() expects an iterable value');
-            }
-        }
-
-        foreach ($iterator as $item) {
+        foreach ($enums as $item) {
             if ($item === $this) {
                 return true;
             }
@@ -43,7 +31,7 @@ trait Comparable
         return false;
     }
 
-    public function notIn(array|object $enums): bool
+    public function notIn(iterable $enums): bool
     {
         return ! $this->in($enums);
     }

--- a/src/Comparable.php
+++ b/src/Comparable.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace ArchTech\Enums;
 
-use Exception;
-use Iterator;
-use IteratorAggregate;
-
 trait Comparable
 {
     public function is(mixed $enum): bool

--- a/src/Comparable.php
+++ b/src/Comparable.php
@@ -19,7 +19,7 @@ trait Comparable
     public function in(iterable $enums): bool
     {
         foreach ($enums as $item) {
-            if ($item === $this) {
+            if ($this->is($item)) {
                 return true;
             }
         }

--- a/src/From.php
+++ b/src/From.php
@@ -15,7 +15,7 @@ trait From
      *
      * @throws ValueError
      */
-    public static function from(string $case): static
+    public static function from(int|string $case): static
     {
         return static::fromName($case);
     }
@@ -25,7 +25,7 @@ trait From
      *
      * This will not override the `tryFrom()` method on BackedEnums
      */
-    public static function tryFrom(string $case): ?static
+    public static function tryFrom(int|string $case): ?static
     {
         return static::tryFromName($case);
     }

--- a/src/From.php
+++ b/src/From.php
@@ -37,7 +37,7 @@ trait From
      */
     public static function fromName(string $case): static
     {
-        return static::tryFromName($case) ?? throw new ValueError('"' . $case . '" is not a valid name for enum ' . static::class . '');
+        return static::tryFromName($case) ?? throw new ValueError('"' . $case . '" is not a valid name for enum ' . static::class);
     }
 
     /**

--- a/src/InvokableCases.php
+++ b/src/InvokableCases.php
@@ -15,7 +15,7 @@ trait InvokableCases
     }
 
     /** Return the enum's value or name when it's called ::STATICALLY(). */
-    public static function __callStatic($name, $args)
+    public static function __callStatic(string $name, array $args)
     {
         $cases = static::cases();
 

--- a/src/Meta/Reflection.php
+++ b/src/Meta/Reflection.php
@@ -25,11 +25,12 @@ class Reflection
         // Traits except the `Metadata` trait
         $traits = array_values(array_filter($reflection->getTraits(), fn (ReflectionClass $class) => $class->getName() !== 'ArchTech\Enums\Metadata'));
 
-        foreach ($traits as $trait) {
-            $metaProperties = array_merge($metaProperties, static::parseMetaProperties($trait));
-        }
+        $traitsMeta = array_map(
+            fn (ReflectionClass $trait) => static::parseMetaProperties($trait),
+            $traits
+        );
 
-        return $metaProperties;
+        return array_merge($metaProperties, ...$traitsMeta);
     }
 
     /** @param ReflectionClass<object> $reflection */

--- a/src/Meta/Reflection.php
+++ b/src/Meta/Reflection.php
@@ -73,6 +73,6 @@ class Reflection
             return $properties[0]->value;
         }
 
-        return $metaProperty::defaultValue() ?? null;
+        return $metaProperty::defaultValue();
     }
 }

--- a/src/Meta/Reflection.php
+++ b/src/Meta/Reflection.php
@@ -51,6 +51,7 @@ class Reflection
     /**
      * Get the value of a meta property on the provided enum.
      *
+     * @param class-string<MetaProperty> $metaProperty
      * @param \Enum $enum
      */
     public static function metaValue(string $metaProperty, mixed $enum): mixed

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -30,7 +30,7 @@ trait Metadata
         );
     }
 
-    public function __call(string $property, $arguments): mixed
+    public function __call(string $property, array $arguments): mixed
     {
         $metaProperties = Meta\Reflection::metaProperties($this);
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -33,7 +33,7 @@ trait Options
 
         // [name, name]
         $options = static::options();
-        if (!$firstCase instanceof BackedEnum) {
+        if (! $firstCase instanceof BackedEnum) {
             // [name => name, name => name]
             $options = array_combine($options, $options);
         }

--- a/src/Options.php
+++ b/src/Options.php
@@ -29,13 +29,11 @@ trait Options
 
         if ($firstCase === null) {
             return '';
-        } elseif ($firstCase instanceof BackedEnum) {
-            // [name => value]
-            $options = static::options();
-        } else {
-            // [name, name]
-            $options = static::options();
+        }
 
+        // [name, name]
+        $options = static::options();
+        if (!$firstCase instanceof BackedEnum) {
             // [name => name, name => name]
             $options = array_combine($options, $options);
         }

--- a/tests/PHPStan/InvokableCases/InvokableCasesTestCase.php
+++ b/tests/PHPStan/InvokableCases/InvokableCasesTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ArchTech\Enums\Tests\PHPStan\InvokableCases;
 
 use PHPStan\Analyser\OutOfClassScope;

--- a/tests/PHPStan/InvokableCasesTest.php
+++ b/tests/PHPStan/InvokableCasesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use ArchTech\Enums\Tests\PHPStan\InvokableCases\InvokableCasesTestCase;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\StringType;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use ArchTech\Enums\{Comparable, InvokableCases, Options, Names, Values, From, Metadata};
 use ArchTech\Enums\Meta\Meta;
 use ArchTech\Enums\Meta\MetaProperty;

--- a/tests/Pest/ComparableTest.php
+++ b/tests/Pest/ComparableTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 test('the is method checks for equality', function () {
     expect(Status::PENDING->is(Status::PENDING))->toBeTrue();
     expect(Status::PENDING->is(Status::DONE))->toBeFalse();

--- a/tests/Pest/ComparableTest.php
+++ b/tests/Pest/ComparableTest.php
@@ -23,6 +23,11 @@ it('the in method checks for presence in an array', function () {
     expect(Status::PENDING->in([Status::PENDING, Status::DONE]))->toBeTrue();
     expect(Role::ADMIN->in([Role::ADMIN]))->toBeTrue();
 
+    $iterator = new ArrayIterator([Status::PENDING, Status::DONE]);
+    expect(Status::PENDING->in($iterator))->toBeTrue();
+    expect(Status::DONE->in($iterator))->toBeTrue();
+    expect(Status::PENDING->in(new ArrayIterator([Role::ADMIN, Role::GUEST])))->toBeFalse();
+
     expect(Status::PENDING->in([Status::DONE]))->toBeFalse();
     expect(Status::PENDING->in([Role::ADMIN, Role::GUEST]))->toBeFalse();
 });

--- a/tests/Pest/FromTest.php
+++ b/tests/Pest/FromTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 it('does not override the default BackedEnum from method')
     ->expect(Status::from(0))
     ->toBe(Status::PENDING);

--- a/tests/Pest/InvokableCasesTest.php
+++ b/tests/Pest/InvokableCasesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use ArchTech\Enums\Exceptions\UndefinedCaseError;
 
 it('can be used as a static method with backed enums', function () {

--- a/tests/Pest/MetadataTest.php
+++ b/tests/Pest/MetadataTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 test('pure enums can have metadata on cases', function () {
     expect(Role::ADMIN->color())->toBe('indigo');
     expect(Role::GUEST->color())->toBe('gray');

--- a/tests/Pest/NamesTest.php
+++ b/tests/Pest/NamesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 it('can return an array of case names from backed enums')
     ->expect(Status::names())
     ->toBe(['PENDING', 'DONE']);

--- a/tests/Pest/OptionsTest.php
+++ b/tests/Pest/OptionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 it('can return an associative array of options from a backed enum')
     ->expect(Status::options())->toBe([
         'PENDING' => 0,

--- a/tests/Pest/TraitTest.php
+++ b/tests/Pest/TraitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use ArchTech\Enums\Meta\Meta;
 use ArchTech\Enums\Meta\MetaProperty;
 use ArchTech\Enums\Metadata;

--- a/tests/Pest/ValuesTest.php
+++ b/tests/Pest/ValuesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 it('can return an array of case values from a backed enum')
     ->expect(Status::values())
     ->toBe([0, 1]);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ArchTech\Enums\Tests;
 
 use Orchestra\Testbench\TestCase as TestbenchTestCase;


### PR DESCRIPTION
- Extended `.gitignore` with `.idea` (for IntelliJ IDEs) and `.phpunit.cache` (for tests)
- Removed unnecessary checks and added proper types instead
- Simplified control flow in some cases
- Added missing types
- Fixed phpstan configuration deprecation
- ~~Added proper typing to `is()` and `isNot()` - [probably BC](https://github.com/archtechx/enums/pull/28/commits/0f63c10dd56a702cc1d8de16aeaee65da196e7c0), even though it'd never make sense to pass anything other than an Enum due to `===` check as `$this` will always be an `UnitEnum` (either pure or backed, both extend this interface), so anything other than an `UnitEnum` will yield a false result~~
  - ~~if this is not the desired behavior and we want users to be able to pass impossible-to-be-true values, I can revert this change~~ moved to https://github.com/archtechx/enums/pull/30