### PR TITLE
Support PHPStan extension-installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,8 @@ includes:
   - ./vendor/archtechx/enums/extension.neon
 ```
 
+*Note: If you have installed [`phpstan/extension-installer`](https://github.com/phpstan/extension-installer#usage), the extension is automatically included.*
+
 ## Development
 
 Run all checks locally:

--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,12 @@
         "allow-plugins": {
             "pestphp/pest-plugin": true
         }
+    },
+    "extra": {
+        "phpstan": {
+            "includes": [
+                "extension.neon"
+            ]
+        }
     }
 }


### PR DESCRIPTION
This PR includes support for the PHPStan [extension-installer](https://github.com/phpstan/extension-installer) to enable automatic loading of the extension.